### PR TITLE
Refactor for implementation change to iframe

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -16,11 +16,17 @@
 </script>
 
 <style lang="scss" scoped>
+  // Hide thread-list when document (=iframe) width is narrow.
+  @media screen and (max-width: 480px) {
+    #thread-list-container {
+      display: none;
+    }
+  }
   #thread-list-container {
     position: absolute;
     right: 35px;
     top: 100px;
     width: 300px;
-    z-index: 1;
+    z-index: 950; // z-index of floating container is 997. Display this further back than that.
   }
 </style>

--- a/src/components/ThreadList.vue
+++ b/src/components/ThreadList.vue
@@ -38,24 +38,17 @@
 
       onMounted(() => {
         const delayRefresh = () => {
-          setTimeout(refreshThreads, 300);
+          // implementation was changed to `iframe` and the load timing became slower,
+          // so the delay time was increased.
+          setTimeout(refreshThreads, 1000);
         };
 
         // watch change of room.
         const roomObserver = new MutationObserver(delayRefresh);
-        // FIXME: change target tag.
+        // change target tag.
         roomObserver.observe(document.getElementsByTagName('body')[0], {
           attributes: true,
         });
-
-        // // TODO: watch change of thread.
-        // const observedEl = document.querySelectorAll('[role="main"]')[0]
-        //   .children[0].children[0].children[0];
-        // const threadObserver = new MutationObserver(delayRefresh);
-        // threadObserver.observe(observedEl, {
-        //   attributes: true,
-        //   childList: true,
-        // });
       });
 
       /**
@@ -68,34 +61,30 @@
           if (el.hasAttribute('aria-label')) headers.push(el);
         }
 
-        // FIXME: iframe のコンテンツを取得できなかったので諦め><
-        console.log(`headings:`);
-        console.log(headings);
-
         // clear state
         state.threads = [];
 
-        // // スレッド情報を取得
-        // headers.forEach(el => {
-        //   // タイトルから不要な情報を削除
-        //   let heading = el.innerHTML;
+        // スレッド情報を取得
+        headers.forEach(el => {
+          // タイトルから不要な情報を削除
+          let heading = el.innerHTML;
 
-        //   // タイトルの文字列を取得
-        //   const headArr = heading.split('.');
-        //   const idx = headArr[0].indexOf('未読') === -1 ? 1 : 2;
-        //   let title = headArr[idx];
+          // タイトルの文字列を取得
+          const headArr = heading.split('.');
+          const idx = headArr[0].indexOf('未読') === -1 ? 1 : 2;
+          let title = headArr[idx];
 
-        //   // bold文字をreplace
-        //   const regex = /\*/gi;
-        //   title = title.replace(regex, '');
+          // bold文字をreplace
+          const regex = /\*/gi;
+          title = title.replace(regex, '');
 
-        //   // スレッド情報をstate.threadsに詰める
-        //   const thread = {
-        //     el: el,
-        //     title: title,
-        //   };
-        //   state.threads.push(thread);
-        // });
+          // スレッド情報をstate.threadsに詰める
+          const thread = {
+            el: el,
+            title: title,
+          };
+          state.threads.push(thread);
+        });
       };
 
       // when thread clicked, scroll to it

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -5,7 +5,7 @@
   "description": "Display Thread Link in Google Chat",
   "content_scripts": [
     {
-      "matches": ["https://mail.google.com/chat/*"],
+      "matches": ["https://chat.google.com/*"],
       "js": ["js/chunk-vendors.js", "js/app.js"],
       "css": ["css/app.css"],
       "run_at": "document_end",


### PR DESCRIPTION
大変便利なプラグインなので、仕様変更対応に contribute して、みんなと嬉しい思いをしたいです。

## 課題点

#10 でも指摘がある通り、Google チャットに下記の変更があった。

* URLが **mail**.google.com に変更
* 実体コンテンツが `iframe` （**chat**.google.com）に移動

従来の実装で親側にプラグインを存在させてしまうと、ifame側にあるコンテンツに到達できず、このプラグインが使用できなくなってしまう。

## 解決法

* このプラグインの動作条件を `iframe` 側に変更する
  * そうすることで Same-Origin Policy を回避する
* チャットゾーン以外にもDMゾーン、チャットルーム一覧ゾーン、右下のチャットルーム小窓ゾーンも `iframe` （chat.google.com）での実装となっているので、泣く泣く「ifameのdocumentの幅」で表示制限させる
  * 小さいゾーンは CSS で非表示になる
* このプラグインの要素追加と Google チャット側の要素追加が微妙なタイミングで、タイミングによってはプラグインが iframe の裏に隠れてしまう
  * そのため、こちらも泣く泣く z-index を指定して回避
* `iframe` への実装変更によってロード時間が延びていたため、スレッド情報読み込みの 300ms 遅延を 1,000ms に調整
